### PR TITLE
Track free/inflated pages in a Balloon device

### DIFF
--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -719,6 +719,13 @@ definitions:
       stats_polling_interval_s:
         type: integer
         description: Interval in seconds between refreshing statistics. A non-zero value will enable the statistics. Defaults to 0.
+      track_free_pages:
+        type: boolean
+        description:
+          Whether to track inflated pages for snapshot optimization. When enabled, the balloon
+          device will maintain a bitmap of inflated pages that can be used during snapshot creation
+          to zero free pages in memory files for better compression. This adds minimal runtime
+          overhead but improves snapshot compression ratios. Defaults to false.
 
   BalloonUpdate:
     type: object
@@ -730,6 +737,13 @@ definitions:
       amount_mib:
         type: integer
         description: Target balloon size in MiB.
+      track_free_pages:
+        type: boolean
+        description:
+          Whether to track inflated pages for snapshot optimization. When enabled, the balloon
+          device will maintain a bitmap of inflated pages that can be used during snapshot creation
+          to zero free pages in memory files for better compression. This adds minimal runtime
+          overhead but improves snapshot compression ratios. Can be toggled at runtime.
 
   BalloonStats:
     type: object
@@ -893,7 +907,7 @@ definitions:
       path_on_host:
         type: string
         description:
-          Host level path for the guest drive. 
+          Host level path for the guest drive.
           This field is required for virtio-block config and should be omitted for vhost-user-block configuration.
       rate_limiter:
         $ref: "#/definitions/RateLimiter"

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -767,6 +767,13 @@ definitions:
       actual_mib:
         description: Actual amount of memory (in MiB) the device is holding.
         type: integer
+      tracked_free_pages:
+        description: |
+          Number of pages currently tracked as free/inflated in the internal bitmap.
+          Only present when track_free_pages is enabled. This shows the actual count
+          of set bits in the internal tracking bitmap, which may differ from actual_pages
+          based on guest memory usage patterns.
+        type: integer
       swap_in:
         description: The amount of memory that has been swapped in (in bytes).
         type: integer

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -888,12 +888,12 @@ definitions:
       is_read_only:
         type: boolean
         description:
-          Is block read only. 
+          Is block read only.
           This field is required for virtio-block config and should be omitted for vhost-user-block configuration.
       path_on_host:
         type: string
         description:
-          Host level path for the guest drive.
+          Host level path for the guest drive. 
           This field is required for virtio-block config and should be omitted for vhost-user-block configuration.
       rate_limiter:
         $ref: "#/definitions/RateLimiter"

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -76,6 +76,8 @@ pub struct BalloonConfig {
     pub deflate_on_oom: bool,
     /// Interval of time in seconds at which the balloon statistics are updated.
     pub stats_polling_interval_s: u16,
+    /// Whether to track inflated pages for snapshot optimization.
+    pub track_free_pages: bool,
 }
 
 /// BalloonStats holds statistics returned from the stats_queue.
@@ -247,6 +249,8 @@ pub struct Balloon {
     pub(crate) pfn_buffer: [u32; MAX_PAGE_COMPACT_BUFFER],
     // Memory-efficient bitmap for tracking inflated pages
     pub(crate) inflated_pages: Option<InflatedPagesBitmap>,
+    // Whether to track free pages for snapshot optimization
+    pub(crate) track_free_pages: bool,
 }
 
 // TODO Use `#[derive(Debug)]` when a new release of
@@ -270,6 +274,7 @@ impl fmt::Debug for Balloon {
             .field("pfn_buffer", &self.pfn_buffer)
             .field("inflated_pages_count", &self.inflated_pages.as_ref().map(|b| b.count_inflated()).unwrap_or(0))
             .field("inflated_pages_overhead_bytes", &self.inflated_pages.as_ref().map(|b| b.memory_overhead_bytes()).unwrap_or(0))
+            .field("track_free_pages", &self.track_free_pages)
             .finish()
     }
 }
@@ -281,6 +286,7 @@ impl Balloon {
         deflate_on_oom: bool,
         stats_polling_interval_s: u16,
         restored_from_file: bool,
+        track_free_pages: bool,
     ) -> Result<Balloon, BalloonError> {
         let mut avail_features = 1u64 << VIRTIO_F_VERSION_1;
 
@@ -327,7 +333,9 @@ impl Balloon {
             stats_desc_index: None,
             latest_stats: BalloonStats::default(),
             pfn_buffer: [0u32; MAX_PAGE_COMPACT_BUFFER],
-            inflated_pages: None,
+            // Only initialize tracking if explicitly enabled to avoid unnecessary memory overhead
+            inflated_pages: if track_free_pages { Some(InflatedPagesBitmap::new(0)) } else { None },
+            track_free_pages,
         })
     }
 
@@ -605,6 +613,35 @@ impl Balloon {
         Ok(())
     }
 
+    /// Update whether to track free pages for snapshot optimization.
+    /// This can be enabled or disabled at runtime.
+    pub fn update_track_free_pages(&mut self, track_free_pages: bool) -> Result<(), BalloonError> {
+        if self.track_free_pages == track_free_pages {
+            return Ok(()); // No change needed
+        }
+
+        self.track_free_pages = track_free_pages;
+
+        if track_free_pages {
+            // Enable tracking - initialize bitmap if device is activated
+            if self.is_activated() {
+                let total_memory_bytes: u64 = self.device_state.mem().unwrap()
+                    .iter().map(|region| region.len()).sum();
+                const PAGE_SIZE: u64 = 4096;
+                let total_pages = (total_memory_bytes / PAGE_SIZE) as u32;
+                self.inflated_pages = Some(InflatedPagesBitmap::new(total_pages));
+            } else {
+                // Device not activated yet, will be initialized on activation
+                self.inflated_pages = Some(InflatedPagesBitmap::new(0));
+            }
+        } else {
+            // Disable tracking - clear bitmap to free memory
+            self.inflated_pages = None;
+        }
+
+        Ok(())
+    }
+
     pub fn update_timer_state(&mut self) {
         let timer_state = TimerState::Periodic {
             current: Duration::from_secs(u64::from(self.stats_polling_interval_s)),
@@ -632,6 +669,11 @@ impl Balloon {
         self.stats_polling_interval_s
     }
 
+    /// Check if free pages tracking is enabled.
+    pub fn track_free_pages(&self) -> bool {
+        self.track_free_pages
+    }
+
     /// Retrieve latest stats for the balloon device.
     pub fn latest_stats(&mut self) -> Option<&BalloonStats> {
         if self.stats_enabled() {
@@ -651,6 +693,7 @@ impl Balloon {
             amount_mib: self.size_mb(),
             deflate_on_oom: self.deflate_on_oom(),
             stats_polling_interval_s: self.stats_polling_interval_s(),
+            track_free_pages: self.track_free_pages(),
         }
     }
 
@@ -726,11 +769,13 @@ impl VirtioDevice for Balloon {
                 .map_err(ActivateError::QueueMemoryError)?;
         }
 
-        // Initialize the inflated pages bitmap based on guest memory size
-        let total_memory_bytes: u64 = mem.iter().map(|region| region.len()).sum();
-        const PAGE_SIZE: u64 = 4096;
-        let total_pages = (total_memory_bytes / PAGE_SIZE) as u32;
-        self.inflated_pages = Some(InflatedPagesBitmap::new(total_pages));
+        // Initialize the inflated pages bitmap based on guest memory size if tracking is enabled
+        if self.inflated_pages.is_some() {
+            let total_memory_bytes: u64 = mem.iter().map(|region| region.len()).sum();
+            const PAGE_SIZE: u64 = 4096;
+            let total_pages = (total_memory_bytes / PAGE_SIZE) as u32;
+            self.inflated_pages = Some(InflatedPagesBitmap::new(total_pages));
+        }
 
         self.device_state = DeviceState::Activated(mem);
         if self.activate_evt.write(1).is_err() {
@@ -849,7 +894,7 @@ pub(crate) mod tests {
         // Test all feature combinations.
         for deflate_on_oom in [true, false].iter() {
             for stats_interval in [0, 1].iter() {
-                let mut balloon = Balloon::new(0, *deflate_on_oom, *stats_interval, false).unwrap();
+                let mut balloon = Balloon::new(0, *deflate_on_oom, *stats_interval, false, false).unwrap();
                 assert_eq!(balloon.device_type(), TYPE_BALLOON);
 
                 let features: u64 = (1u64 << VIRTIO_F_VERSION_1)
@@ -876,12 +921,13 @@ pub(crate) mod tests {
 
     #[test]
     fn test_virtio_read_config() {
-        let balloon = Balloon::new(0x10, true, 0, false).unwrap();
+        let balloon = Balloon::new(0x10, true, 0, false, false).unwrap();
 
         let cfg = BalloonConfig {
             amount_mib: 16,
             deflate_on_oom: true,
             stats_polling_interval_s: 0,
+            track_free_pages: false,
         };
         assert_eq!(balloon.config(), cfg);
 
@@ -910,7 +956,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_virtio_write_config() {
-        let mut balloon = Balloon::new(0, true, 0, false).unwrap();
+        let mut balloon = Balloon::new(0, true, 0, false, false).unwrap();
 
         let expected_config_space: [u8; BALLOON_CONFIG_SPACE_SIZE] =
             [0x00, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
@@ -936,7 +982,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_invalid_request() {
-        let mut balloon = Balloon::new(0, true, 0, false).unwrap();
+        let mut balloon = Balloon::new(0, true, 0, false, false).unwrap();
         let mem = default_mem();
         // Only initialize the inflate queue to demonstrate invalid request handling.
         let infq = VirtQueue::new(GuestAddress(0), &mem, 16);
@@ -995,7 +1041,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_inflate() {
-        let mut balloon = Balloon::new(0, true, 0, false).unwrap();
+        let mut balloon = Balloon::new(0, true, 0, false, false).unwrap();
         let mem = default_mem();
         let infq = VirtQueue::new(GuestAddress(0), &mem, 16);
         balloon.set_queue(INFLATE_INDEX, infq.create_queue());
@@ -1065,7 +1111,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_deflate() {
-        let mut balloon = Balloon::new(0, true, 0, false).unwrap();
+        let mut balloon = Balloon::new(0, true, 0, false, false).unwrap();
         let mem = default_mem();
         let defq = VirtQueue::new(GuestAddress(0), &mem, 16);
         balloon.set_queue(DEFLATE_INDEX, defq.create_queue());
@@ -1113,7 +1159,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_stats() {
-        let mut balloon = Balloon::new(0, true, 1, false).unwrap();
+        let mut balloon = Balloon::new(0, true, 1, false, false).unwrap();
         let mem = default_mem();
         let statsq = VirtQueue::new(GuestAddress(0), &mem, 16);
         balloon.set_queue(STATS_INDEX, statsq.create_queue());
@@ -1200,7 +1246,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_process_balloon_queues() {
-        let mut balloon = Balloon::new(0x10, true, 0, false).unwrap();
+        let mut balloon = Balloon::new(0x10, true, 0, false, false).unwrap();
         let mem = default_mem();
         let infq = VirtQueue::new(GuestAddress(0), &mem, 16);
         let defq = VirtQueue::new(GuestAddress(0), &mem, 16);
@@ -1214,7 +1260,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_update_stats_interval() {
-        let mut balloon = Balloon::new(0, true, 0, false).unwrap();
+        let mut balloon = Balloon::new(0, true, 0, false, false).unwrap();
         let mem = default_mem();
         balloon.activate(mem).unwrap();
         assert_eq!(
@@ -1223,7 +1269,7 @@ pub(crate) mod tests {
         );
         balloon.update_stats_polling_interval(0).unwrap();
 
-        let mut balloon = Balloon::new(0, true, 1, false).unwrap();
+        let mut balloon = Balloon::new(0, true, 1, false, false).unwrap();
         let mem = default_mem();
         balloon.activate(mem).unwrap();
         assert_eq!(
@@ -1236,14 +1282,14 @@ pub(crate) mod tests {
 
     #[test]
     fn test_cannot_update_inactive_device() {
-        let mut balloon = Balloon::new(0, true, 0, false).unwrap();
+        let mut balloon = Balloon::new(0, true, 0, false, false).unwrap();
         // Assert that we can't update an inactive device.
         balloon.update_size(1).unwrap_err();
     }
 
     #[test]
     fn test_num_pages() {
-        let mut balloon = Balloon::new(0, true, 0, false).unwrap();
+        let mut balloon = Balloon::new(0, true, 0, false, false).unwrap();
         // Switch the state to active.
         balloon.device_state = DeviceState::Activated(single_region_mem(0x1));
 
@@ -1272,18 +1318,59 @@ pub(crate) mod tests {
 
     #[test]
     fn test_inflated_pages_tracking() {
-        let mut balloon = Balloon::new(0, true, 0, false).unwrap();
+        // Enable tracking by passing true for track_free_pages
+        let mut balloon = Balloon::new(0, true, 0, false, true).unwrap();
         let mem = default_mem();
         balloon.activate(mem.clone()).unwrap();
 
         // Initially no pages should be inflated
         assert_eq!(balloon.inflated_pages().len(), 0);
 
-        // Verify memory overhead is reasonable
+        // Verify memory overhead is reasonable when tracking is enabled
         if let Some(overhead) = balloon.tracking_memory_overhead() {
             // For a small test memory, overhead should be minimal
             assert!(overhead < 1024); // Less than 1KB overhead
+        } else {
+            panic!("Memory tracking should be enabled and return overhead information");
         }
+
+        // Test that we can track inflated pages
+        if let Some(ref mut bitmap) = balloon.inflated_pages {
+            bitmap.set_inflated(100);
+            bitmap.set_inflated(200);
+            assert_eq!(bitmap.count_inflated(), 2);
+            assert!(bitmap.is_inflated(100));
+            assert!(bitmap.is_inflated(200));
+            assert!(!bitmap.is_inflated(150));
+        } else {
+            panic!("Inflated pages bitmap should be initialized when tracking is enabled");
+        }
+
+        // Test that inflated_pages() method returns the correct data
+        let inflated_set = balloon.inflated_pages();
+        assert_eq!(inflated_set.len(), 2);
+        assert!(inflated_set.contains(&100));
+        assert!(inflated_set.contains(&200));
+    }
+
+    #[test]
+    fn test_inflated_pages_tracking_disabled() {
+        // Disable tracking by passing false for track_free_pages
+        let mut balloon = Balloon::new(0, true, 0, false, false).unwrap();
+        let mem = default_mem();
+        balloon.activate(mem.clone()).unwrap();
+
+        // When tracking is disabled, inflated_pages should return empty set
+        assert_eq!(balloon.inflated_pages().len(), 0);
+
+        // Memory overhead should be None when tracking is disabled
+        assert!(balloon.tracking_memory_overhead().is_none());
+
+        // track_free_pages should return false
+        assert!(!balloon.track_free_pages());
+
+        // inflated_pages should be None
+        assert!(balloon.inflated_pages.is_none());
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -3,6 +3,7 @@
 
 use std::fmt;
 use std::time::Duration;
+use std::collections::HashSet;
 
 use log::error;
 use serde::Serialize;
@@ -150,6 +151,76 @@ impl BalloonStats {
     }
 }
 
+/// Efficient bitmap for tracking inflated pages during VM runtime.
+/// This uses much less memory than storing individual page numbers.
+#[derive(Debug)]
+struct InflatedPagesBitmap {
+    /// Bitmap where each bit represents whether a page is inflated (1) or not (0).
+    bitmap: Vec<u8>,
+    /// Total number of pages that can be tracked.
+    total_pages: u32,
+}
+
+impl InflatedPagesBitmap {
+    /// Creates a new bitmap for tracking inflated pages.
+    fn new(total_pages: u32) -> Self {
+        let bitmap_bytes = ((total_pages + 7) / 8) as usize;
+        Self {
+            bitmap: vec![0u8; bitmap_bytes],
+            total_pages,
+        }
+    }
+
+    /// Sets a page as inflated.
+    fn set_inflated(&mut self, page_num: u32) {
+        if page_num < self.total_pages {
+            let byte_idx = (page_num / 8) as usize;
+            let bit_idx = page_num % 8;
+            self.bitmap[byte_idx] |= 1 << bit_idx;
+        }
+    }
+
+    /// Clears a page as not inflated.
+    fn clear_inflated(&mut self, page_num: u32) {
+        if page_num < self.total_pages {
+            let byte_idx = (page_num / 8) as usize;
+            let bit_idx = page_num % 8;
+            self.bitmap[byte_idx] &= !(1 << bit_idx);
+        }
+    }
+
+    /// Checks if a page is inflated.
+    fn is_inflated(&self, page_num: u32) -> bool {
+        if page_num >= self.total_pages {
+            return false;
+        }
+        let byte_idx = (page_num / 8) as usize;
+        let bit_idx = page_num % 8;
+        (self.bitmap[byte_idx] & (1 << bit_idx)) != 0
+    }
+
+    /// Returns all inflated page numbers as a HashSet for compatibility with existing APIs.
+    fn to_hashset(&self) -> HashSet<u32> {
+        let mut result = HashSet::new();
+        for page_num in 0..self.total_pages {
+            if self.is_inflated(page_num) {
+                result.insert(page_num);
+            }
+        }
+        result
+    }
+
+    /// Returns the number of inflated pages.
+    fn count_inflated(&self) -> usize {
+        self.bitmap.iter().map(|byte| byte.count_ones() as usize).sum()
+    }
+
+    /// Returns the memory overhead of this bitmap in bytes.
+    fn memory_overhead_bytes(&self) -> usize {
+        self.bitmap.len()
+    }
+}
+
 /// Virtio balloon device.
 pub struct Balloon {
     // Virtio fields.
@@ -174,6 +245,8 @@ pub struct Balloon {
     pub(crate) latest_stats: BalloonStats,
     // A buffer used as pfn accumulator during descriptor processing.
     pub(crate) pfn_buffer: [u32; MAX_PAGE_COMPACT_BUFFER],
+    // Memory-efficient bitmap for tracking inflated pages
+    pub(crate) inflated_pages: Option<InflatedPagesBitmap>,
 }
 
 // TODO Use `#[derive(Debug)]` when a new release of
@@ -195,6 +268,8 @@ impl fmt::Debug for Balloon {
             .field("stats_desc_index", &self.stats_desc_index)
             .field("latest_stats", &self.latest_stats)
             .field("pfn_buffer", &self.pfn_buffer)
+            .field("inflated_pages_count", &self.inflated_pages.as_ref().map(|b| b.count_inflated()).unwrap_or(0))
+            .field("inflated_pages_overhead_bytes", &self.inflated_pages.as_ref().map(|b| b.memory_overhead_bytes()).unwrap_or(0))
             .finish()
     }
 }
@@ -252,6 +327,7 @@ impl Balloon {
             stats_desc_index: None,
             latest_stats: BalloonStats::default(),
             pfn_buffer: [0u32; MAX_PAGE_COMPACT_BUFFER],
+            inflated_pages: None,
         })
     }
 
@@ -322,6 +398,7 @@ impl Balloon {
                         break;
                     }
 
+                    // Process all page frame numbers in this descriptor
                     // This is safe, `len` was validated above.
                     for index in (0..len).step_by(SIZE_OF_U32) {
                         let addr = head
@@ -334,6 +411,10 @@ impl Balloon {
                             .map_err(|_| BalloonError::MalformedDescriptor)?;
 
                         self.pfn_buffer[pfn_buffer_idx] = page_frame_number;
+                        // Track this page as inflated directly during queue processing
+                        if let Some(ref mut bitmap) = self.inflated_pages {
+                            bitmap.set_inflated(page_frame_number);
+                        }
                         pfn_buffer_idx += 1;
                     }
                 }
@@ -364,19 +445,40 @@ impl Balloon {
         }
 
         if needs_interrupt {
-            self.signal_used_queue()?;
+           self.signal_used_queue()?;
         }
 
         Ok(())
     }
 
     pub(crate) fn process_deflate_queue(&mut self) -> Result<(), BalloonError> {
+        // This is safe since we checked in the event handler that the device is activated.
+        let mem = self.device_state.mem().unwrap();
         METRICS.deflate_count.inc();
 
         let queue = &mut self.queues[DEFLATE_INDEX];
         let mut needs_interrupt = false;
 
         while let Some(head) = queue.pop()? {
+            let len = head.len as usize;
+
+            // Process deflate descriptors to track which pages are no longer inflated
+            // Note: Original deflate had no length restrictions, so we don't check MAX_PAGES_IN_DESC
+            if !head.is_write_only() && len % SIZE_OF_U32 == 0 {
+                // Process all page frame numbers in this descriptor directly
+                // This is safe, `len` was validated above.
+                for index in (0..len).step_by(SIZE_OF_U32) {
+                    if let Some(addr) = head.addr.checked_add(index as u64) {
+                        if let Ok(page_frame_number) = mem.read_obj::<u32>(addr) {
+                            // Remove this page from inflated pages set directly during queue processing
+                            if let Some(ref mut bitmap) = self.inflated_pages {
+                                bitmap.clear_inflated(page_frame_number);
+                            }
+                        }
+                    }
+                }
+            }
+
             queue.add_used(head.index, 0)?;
             needs_interrupt = true;
         }
@@ -446,6 +548,20 @@ impl Balloon {
     /// Provides the ID of this balloon device.
     pub fn id(&self) -> &str {
         BALLOON_DEV_ID
+    }
+
+    /// Returns the set of inflated page frame numbers.
+    /// These pages are considered free from the guest perspective.
+    pub fn inflated_pages(&self) -> HashSet<u32> {
+        self.inflated_pages
+            .as_ref()
+            .map(|bitmap| bitmap.to_hashset())
+            .unwrap_or_default()
+    }
+
+    /// Returns memory overhead information for tracking inflated pages.
+    pub fn tracking_memory_overhead(&self) -> Option<usize> {
+        self.inflated_pages.as_ref().map(|bitmap| bitmap.memory_overhead_bytes())
     }
 
     fn trigger_stats_update(&mut self) -> Result<(), BalloonError> {
@@ -609,6 +725,12 @@ impl VirtioDevice for Balloon {
             q.initialize(&mem)
                 .map_err(ActivateError::QueueMemoryError)?;
         }
+
+        // Initialize the inflated pages bitmap based on guest memory size
+        let total_memory_bytes: u64 = mem.iter().map(|region| region.len()).sum();
+        const PAGE_SIZE: u64 = 4096;
+        let total_pages = (total_memory_bytes / PAGE_SIZE) as u32;
+        self.inflated_pages = Some(InflatedPagesBitmap::new(total_pages));
 
         self.device_state = DeviceState::Activated(mem);
         if self.activate_evt.write(1).is_err() {
@@ -1146,5 +1268,67 @@ pub(crate) mod tests {
         balloon.write_config(0, &expected_config);
         assert_eq!(balloon.num_pages(), 0x1122_3344);
         assert_eq!(balloon.actual_pages(), 0x1234_5678);
+    }
+
+    #[test]
+    fn test_inflated_pages_tracking() {
+        let mut balloon = Balloon::new(0, true, 0, false).unwrap();
+        let mem = default_mem();
+        balloon.activate(mem.clone()).unwrap();
+
+        // Initially no pages should be inflated
+        assert_eq!(balloon.inflated_pages().len(), 0);
+
+        // Verify memory overhead is reasonable
+        if let Some(overhead) = balloon.tracking_memory_overhead() {
+            // For a small test memory, overhead should be minimal
+            assert!(overhead < 1024); // Less than 1KB overhead
+        }
+    }
+
+    #[test]
+    fn test_bitmap_memory_efficiency() {
+        // Test that bitmap uses much less memory than HashSet for large memory
+        let total_pages = 1_000_000u32; // ~4GB worth of pages
+        let bitmap = InflatedPagesBitmap::new(total_pages);
+
+        // Bitmap should use about 125KB (1M bits / 8 bits per byte)
+        let expected_bitmap_bytes = (total_pages + 7) / 8;
+        assert_eq!(bitmap.memory_overhead_bytes(), expected_bitmap_bytes as usize);
+
+        // Compare with what a HashSet would use for all pages
+        let hashset_overhead_per_entry = std::mem::size_of::<u32>() + 8; // Conservative estimate
+        let full_hashset_overhead = total_pages as usize * hashset_overhead_per_entry;
+
+        // Bitmap should be much more efficient
+        assert!(bitmap.memory_overhead_bytes() < full_hashset_overhead / 10);
+    }
+
+    #[test]
+    fn test_bitmap_operations() {
+        let mut bitmap = InflatedPagesBitmap::new(1000);
+
+        // Test setting and checking pages
+        bitmap.set_inflated(100);
+        bitmap.set_inflated(200);
+        bitmap.set_inflated(300);
+
+        assert!(bitmap.is_inflated(100));
+        assert!(bitmap.is_inflated(200));
+        assert!(bitmap.is_inflated(300));
+        assert!(!bitmap.is_inflated(150));
+        assert_eq!(bitmap.count_inflated(), 3);
+
+        // Test clearing
+        bitmap.clear_inflated(200);
+        assert!(!bitmap.is_inflated(200));
+        assert_eq!(bitmap.count_inflated(), 2);
+
+        // Test conversion to HashSet
+        let hashset = bitmap.to_hashset();
+        assert!(hashset.contains(&100));
+        assert!(!hashset.contains(&200));
+        assert!(hashset.contains(&300));
+        assert_eq!(hashset.len(), 2);
     }
 }

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -93,6 +93,11 @@ pub struct BalloonStats {
     pub target_mib: u32,
     /// The number of MiB the device is currently holding.
     pub actual_mib: u32,
+    /// Number of pages currently tracked as free/inflated in the bitmap.
+    /// Only present when track_free_pages is enabled. This shows the actual
+    /// count of set bits in the internal tracking bitmap.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tracked_free_pages: Option<u32>,
     /// Amount of memory swapped in.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub swap_in: Option<u64>,
@@ -682,6 +687,14 @@ impl Balloon {
             self.latest_stats.actual_pages = self.config_space.actual_pages;
             self.latest_stats.target_mib = pages_to_mib(self.latest_stats.target_pages);
             self.latest_stats.actual_mib = pages_to_mib(self.latest_stats.actual_pages);
+
+            // Add tracked free pages count if tracking is enabled
+            self.latest_stats.tracked_free_pages = if self.track_free_pages {
+                self.inflated_pages.as_ref().map(|bitmap| bitmap.count_inflated() as u32)
+            } else {
+                None
+            };
+
             Some(&self.latest_stats)
         } else {
             None

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -9,6 +9,7 @@ use log::error;
 use serde::Serialize;
 use timerfd::{ClockId, SetTimeFlags, TimerFd, TimerState};
 use vmm_sys_util::eventfd::EventFd;
+use vm_memory::GuestMemory;
 
 use super::super::device::{DeviceState, VirtioDevice};
 use super::super::queue::Queue;
@@ -30,7 +31,7 @@ use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::queue::InvalidAvailIdx;
 use crate::logger::IncMetric;
 use crate::utils::u64_to_usize;
-use crate::vstate::memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryMmap};
+use crate::vstate::memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryMmap, GuestMemoryRegion};
 
 const SIZE_OF_U32: usize = std::mem::size_of::<u32>();
 const SIZE_OF_STAT: usize = std::mem::size_of::<BalloonStat>();

--- a/src/vmm/src/devices/virtio/balloon/persist.rs
+++ b/src/vmm/src/devices/virtio/balloon/persist.rs
@@ -127,6 +127,7 @@ impl Persist<'_> for Balloon {
             false,
             state.stats_polling_interval_s,
             constructor_args.restored_from_file,
+            false,
         )?;
 
         let mut num_queues = BALLOON_NUM_QUEUES;
@@ -192,7 +193,7 @@ mod tests {
         let mut mem = vec![0; 4096];
 
         // Create and save the balloon device.
-        let balloon = Balloon::new(0x42, false, 2, false).unwrap();
+        let balloon = Balloon::new(0x42, false, 2, false, false).unwrap();
 
         Snapshot::serialize(&mut mem.as_mut_slice(), &balloon.save()).unwrap();
 

--- a/src/vmm/src/devices/virtio/balloon/persist.rs
+++ b/src/vmm/src/devices/virtio/balloon/persist.rs
@@ -41,6 +41,7 @@ pub struct BalloonStatsState {
     disk_caches: Option<u64>,
     hugetlb_allocations: Option<u64>,
     hugetlb_failures: Option<u64>,
+    tracked_free_pages: Option<u32>,
 }
 
 impl BalloonStatsState {
@@ -56,6 +57,7 @@ impl BalloonStatsState {
             disk_caches: stats.disk_caches,
             hugetlb_allocations: stats.hugetlb_allocations,
             hugetlb_failures: stats.hugetlb_failures,
+            tracked_free_pages: stats.tracked_free_pages,
         }
     }
 
@@ -75,6 +77,7 @@ impl BalloonStatsState {
             disk_caches: self.disk_caches,
             hugetlb_allocations: self.hugetlb_allocations,
             hugetlb_failures: self.hugetlb_failures,
+            tracked_free_pages: self.tracked_free_pages,
         }
     }
 }

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -154,6 +154,7 @@ use crate::vstate::memory::{GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
 use crate::vstate::vcpu::VcpuState;
 pub use crate::vstate::vcpu::{Vcpu, VcpuConfig, VcpuEvent, VcpuHandle, VcpuResponse};
 pub use crate::vstate::vm::Vm;
+use crate::vmm_config::balloon::BalloonUpdateConfig;
 
 /// Shorthand type for the EventManager flavour used by Firecracker.
 pub type EventManager = BaseEventManager<Arc<Mutex<dyn MutEventSubscriber>>>;
@@ -697,10 +698,10 @@ impl Vmm {
     }
 
     /// Updates configuration for the balloon device target size.
-    pub fn update_balloon_config(&mut self, amount_mib: u32) -> Result<(), BalloonError> {
+    pub fn update_balloon_config(&mut self, update_config: &BalloonUpdateConfig) -> Result<(), BalloonError> {
         // The balloon cannot have a target size greater than the size of
         // the guest memory.
-        if u64::from(amount_mib) > mem_size_mib(self.vm.guest_memory()) {
+        if u64::from(update_config.amount_mib) > mem_size_mib(self.vm.guest_memory()) {
             return Err(BalloonError::TooManyPagesRequested);
         }
 
@@ -714,13 +715,22 @@ impl Vmm {
                     .expect("Unexpected device type")
                     .device();
 
-                virtio_device
+                let mut balloon = virtio_device
                     .lock()
-                    .expect("Poisoned lock")
+                    .expect("Poisoned lock");
+
+                let balloon_ref = balloon
                     .as_mut_any()
                     .downcast_mut::<Balloon>()
-                    .unwrap()
-                    .update_size(amount_mib)?;
+                    .unwrap();
+
+                // Update balloon size
+                balloon_ref.update_size(update_config.amount_mib)?;
+
+                // Update tracking if specified
+                if let Some(track_free_pages) = update_config.track_free_pages {
+                    balloon_ref.update_track_free_pages(track_free_pages)?;
+                }
 
                 Ok(())
             }

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -129,8 +129,7 @@ pub enum MicrovmStateError {
     UnexpectedVcpuResponse,
 }
 
-/// Errors associated with creating a snapshot.
-#[rustfmt::skip]
+/// Error definitions for the snapshot creation.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum CreateSnapshotError {
     /// Cannot get dirty bitmap: {0}
@@ -145,6 +144,8 @@ pub enum CreateSnapshotError {
     SerializeMicrovmState(#[from] crate::snapshot::SnapshotError),
     /// Cannot perform {0} on the snapshot backing file: {1}
     SnapshotBackingFile(&'static str, io::Error),
+    /// Cannot create free pages bitmap: {0}
+    FreePagesbitmap(#[from] crate::snapshot::free_pages::FreePagesError),
 }
 
 /// Snapshot version
@@ -165,6 +166,15 @@ pub fn create_snapshot(
     vmm.vm
         .snapshot_memory_to_file(&params.mem_file_path, params.snapshot_type)?;
 
+    // For full snapshots, collect free pages and zero them in memory file for better compression
+    if matches!(params.snapshot_type, crate::vmm_config::snapshot::SnapshotType::Full) {
+        let free_pages_bitmap = collect_free_pages_for_zeroing(vmm, vm_info)?;
+        // Only zero pages if there are actually any free pages to optimize
+        if free_pages_bitmap.free_page_count() > 0 {
+            zero_free_pages_in_memory_file(&params.mem_file_path, &free_pages_bitmap)?;
+        }
+    }
+
     // We need to mark queues as dirty again for all activated devices. The reason we
     // do it here is because we don't mark pages as dirty during runtime
     // for queue objects.
@@ -183,6 +193,193 @@ pub fn create_snapshot(
         .unwrap();
 
     Ok(())
+}
+
+/// Collects free pages information from balloon devices for memory zeroing optimization.
+/// This creates a temporary bitmap for zeroing but doesn't save it to a file.
+fn collect_free_pages_for_zeroing(
+    vmm: &Vmm,
+    vm_info: &VmInfo,
+) -> Result<crate::snapshot::free_pages::FreePagesbitmap, CreateSnapshotError> {
+    use crate::snapshot::free_pages::create_free_pages_bitmap;
+    use std::collections::HashSet;
+
+    // Collect inflated pages from all balloon devices
+    let mut all_inflated_pages = HashSet::new();
+
+    vmm.mmio_device_manager
+        .for_each_virtio_device(|_, _, device_type, dev| {
+            if device_type == &crate::devices::virtio::TYPE_BALLOON {
+                let d = dev.lock().unwrap();
+                if let Some(balloon) = d.as_any().downcast_ref::<crate::devices::virtio::balloon::Balloon>() {
+                    let inflated_pages = balloon.inflated_pages();
+                    all_inflated_pages.extend(inflated_pages.iter());
+
+                    // Log memory overhead information
+                    if let Some(overhead) = balloon.tracking_memory_overhead() {
+                        crate::logger::info!(
+                            "Balloon device inflated pages tracking overhead: {} KB, {} pages tracked",
+                            overhead / 1024,
+                            inflated_pages.len()
+                        );
+                    }
+                }
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    // Calculate total memory pages (assuming 4KB pages)
+    const PAGE_SIZE: u32 = 4096;
+    let total_memory_bytes = vm_info.mem_size_mib * 1024 * 1024;
+    let total_pages = total_memory_bytes / PAGE_SIZE as u64;
+
+    // Create the bitmap for zeroing (but don't save to file)
+    let bitmap = create_free_pages_bitmap(&all_inflated_pages, total_pages, PAGE_SIZE)?;
+
+    crate::logger::info!(
+        "Collected free pages for memory zeroing: {} free pages out of {} total pages ({:.2}% free)",
+        bitmap.free_page_count(),
+        total_pages,
+        (bitmap.free_page_count() as f64 / total_pages as f64) * 100.0
+    );
+
+    Ok(bitmap)
+}
+
+/// Efficiently zeros out free pages in the memory file to improve compression.
+/// Uses buffered I/O and batch processing for optimal performance.
+fn zero_free_pages_in_memory_file(
+    mem_file_path: &std::path::Path,
+    bitmap: &crate::snapshot::free_pages::FreePagesbitmap,
+) -> Result<(), CreateSnapshotError> {
+    use std::fs::OpenOptions;
+    use std::io::{BufWriter, Seek, SeekFrom, Write};
+
+    const PAGE_SIZE: u64 = 4096;
+    const ZERO_BUFFER_SIZE: usize = 64 * 1024; // 64KB buffer for efficient I/O
+    const BATCH_SIZE: usize = ZERO_BUFFER_SIZE / PAGE_SIZE as usize; // 16 pages per batch
+
+    // Open the memory file for read/write
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(mem_file_path)
+        .map_err(|err| CreateSnapshotError::MemoryBackingFile("open", err))?;
+
+    let mut writer = BufWriter::new(file);
+    let zero_page = vec![0u8; PAGE_SIZE as usize];
+    let mut pages_zeroed = 0;
+    let mut bytes_zeroed = 0u64;
+
+    // Process free pages in batches for efficiency
+    let mut current_batch = Vec::new();
+
+    // Collect all free pages into batches
+    for page_num in 0..bitmap.total_pages {
+        if bitmap.is_page_free(page_num) {
+            current_batch.push(page_num);
+
+            // Process batch when full or at end
+            if current_batch.len() >= BATCH_SIZE {
+                let batch_result = zero_pages_batch(&mut writer, &current_batch, &zero_page)?;
+                pages_zeroed += batch_result.0;
+                bytes_zeroed += batch_result.1;
+                current_batch.clear();
+            }
+        }
+    }
+
+    // Process remaining pages in the last batch
+    if !current_batch.is_empty() {
+        let batch_result = zero_pages_batch(&mut writer, &current_batch, &zero_page)?;
+        pages_zeroed += batch_result.0;
+        bytes_zeroed += batch_result.1;
+    }
+
+    // Ensure all writes are flushed
+    writer.flush()
+        .map_err(|err| CreateSnapshotError::MemoryBackingFile("flush", err))?;
+
+    crate::logger::info!(
+        "Zeroed {} free pages ({:.2} MB) in memory file for improved compression",
+        pages_zeroed,
+        bytes_zeroed as f64 / (1024.0 * 1024.0)
+    );
+
+    Ok(())
+}
+
+/// Efficiently zeros a batch of pages using optimized I/O operations.
+/// Returns (pages_processed, bytes_written).
+fn zero_pages_batch(
+    writer: &mut BufWriter<std::fs::File>,
+    page_numbers: &[u32],
+    zero_page: &[u8],
+) -> Result<(usize, u64), CreateSnapshotError> {
+    const PAGE_SIZE: u64 = 4096;
+
+    // Sort pages to minimize seek operations
+    let mut sorted_pages = page_numbers.to_vec();
+    sorted_pages.sort_unstable();
+
+    let mut bytes_written = 0u64;
+    let mut consecutive_start = None;
+    let mut consecutive_count = 0;
+
+    for (i, &page_num) in sorted_pages.iter().enumerate() {
+        let page_offset = page_num as u64 * PAGE_SIZE;
+
+        // Check if this page is consecutive with previous ones
+        let is_consecutive = consecutive_start
+            .map(|start: u64| page_offset == start + (consecutive_count * PAGE_SIZE))
+            .unwrap_or(false);
+
+        if is_consecutive {
+            consecutive_count += 1;
+        } else {
+            // Write previous consecutive batch if exists
+            if let Some(start_offset) = consecutive_start {
+                bytes_written += write_consecutive_zeros(writer, start_offset, consecutive_count, zero_page)?;
+            }
+
+            // Start new consecutive batch
+            consecutive_start = Some(page_offset);
+            consecutive_count = 1;
+        }
+
+        // Write final batch if this is the last page
+        if i == sorted_pages.len() - 1 {
+            if let Some(start_offset) = consecutive_start {
+                bytes_written += write_consecutive_zeros(writer, start_offset, consecutive_count, zero_page)?;
+            }
+        }
+    }
+
+    Ok((page_numbers.len(), bytes_written))
+}
+
+/// Writes consecutive zero pages efficiently by minimizing seek operations.
+fn write_consecutive_zeros(
+    writer: &mut BufWriter<std::fs::File>,
+    start_offset: u64,
+    page_count: u64,
+    zero_page: &[u8],
+) -> Result<u64, CreateSnapshotError> {
+    const PAGE_SIZE: u64 = 4096;
+
+    // Seek to the start position
+    writer.get_mut().seek(SeekFrom::Start(start_offset))
+        .map_err(|err| CreateSnapshotError::MemoryBackingFile("seek", err))?;
+
+    // Write consecutive zero pages
+    let total_bytes = page_count * PAGE_SIZE;
+    for _ in 0..page_count {
+        writer.write_all(zero_page)
+            .map_err(|err| CreateSnapshotError::MemoryBackingFile("write", err))?;
+    }
+
+    Ok(total_bytes)
 }
 
 fn snapshot_state_to_file(
@@ -758,5 +955,77 @@ mod tests {
             serde_json::from_slice(&message_buf).unwrap();
 
         assert_eq!(uffd_regions, deserialized);
+    }
+
+    #[test]
+    fn test_zero_pages_batch_efficiency() {
+        use std::collections::HashSet;
+        use std::fs::File;
+        use std::io::{BufWriter, Read, Write};
+        use tempfile::NamedTempFile;
+
+        // Create a temporary file with test data
+        let mut temp_file = NamedTempFile::new().unwrap();
+        let test_data = vec![0xAA; 16384]; // 4 pages of 0xAA
+        temp_file.write_all(&test_data).unwrap();
+        temp_file.flush().unwrap();
+
+        // Create a bitmap with some free pages
+        let mut free_pages = HashSet::new();
+        free_pages.insert(0); // First page
+        free_pages.insert(2); // Third page
+
+        const PAGE_SIZE: u32 = 4096;
+        let bitmap = crate::snapshot::free_pages::FreePagesbitmap::new(&free_pages, 4, PAGE_SIZE).unwrap();
+
+        // Zero out the free pages
+        zero_free_pages_in_memory_file(temp_file.path(), &bitmap).unwrap();
+
+        // Verify the results
+        let mut file = File::open(temp_file.path()).unwrap();
+        let mut buffer = vec![0u8; 16384];
+        file.read_exact(&mut buffer).unwrap();
+
+        // Page 0 should be zeros
+        assert!(buffer[0..4096].iter().all(|&b| b == 0));
+        // Page 1 should still be 0xAA
+        assert!(buffer[4096..8192].iter().all(|&b| b == 0xAA));
+        // Page 2 should be zeros
+        assert!(buffer[8192..12288].iter().all(|&b| b == 0));
+        // Page 3 should still be 0xAA
+        assert!(buffer[12288..16384].iter().all(|&b| b == 0xAA));
+    }
+
+    #[test]
+    fn test_consecutive_pages_optimization() {
+        use std::collections::HashSet;
+        use std::fs::File;
+        use std::io::{BufWriter, Read, Write};
+        use tempfile::NamedTempFile;
+
+        // Create test file
+        let mut temp_file = NamedTempFile::new().unwrap();
+        let test_data = vec![0xFF; 32768]; // 8 pages of 0xFF
+        temp_file.write_all(&test_data).unwrap();
+
+        let file = File::open(temp_file.path()).unwrap();
+        let mut writer = BufWriter::new(file);
+        let zero_page = vec![0u8; 4096];
+
+        // Test consecutive pages (should be optimized)
+        let consecutive_pages = vec![0, 1, 2, 3]; // 4 consecutive pages
+        let (pages_processed, bytes_written) = zero_pages_batch(&mut writer, &consecutive_pages, &zero_page).unwrap();
+
+        assert_eq!(pages_processed, 4);
+        assert_eq!(bytes_written, 16384); // 4 * 4096
+
+        writer.flush().unwrap();
+        drop(writer);
+
+        // Verify all 4 pages are zeroed
+        let mut file = File::open(temp_file.path()).unwrap();
+        let mut buffer = vec![0u8; 16384];
+        file.read_exact(&mut buffer).unwrap();
+        assert!(buffer.iter().all(|&b| b == 0));
     }
 }

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -166,12 +166,34 @@ pub fn create_snapshot(
     vmm.vm
         .snapshot_memory_to_file(&params.mem_file_path, params.snapshot_type)?;
 
-    // For full snapshots, collect free pages and zero them in memory file for better compression
+    // For full snapshots, optimize free pages in memory file for better compression.
+    // This is only done if balloon devices have tracking enabled via their own
+    // track_free_pages configuration. The balloon device controls when to track
+    // inflated pages during runtime, and snapshots leverage this data if available.
     if matches!(params.snapshot_type, crate::vmm_config::snapshot::SnapshotType::Full) {
-        let free_pages_bitmap = collect_free_pages_for_zeroing(vmm, vm_info)?;
-        // Only zero pages if there are actually any free pages to optimize
-        if free_pages_bitmap.free_page_count() > 0 {
-            zero_free_pages_in_memory_file(&params.mem_file_path, &free_pages_bitmap)?;
+        // Check if any balloon devices have tracking enabled
+        let mut has_balloon_tracking = false;
+        vmm.mmio_device_manager
+            .for_each_virtio_device(|_, _, device_type, dev| {
+                if device_type == &crate::devices::virtio::TYPE_BALLOON {
+                    let d = dev.lock().unwrap();
+                    if let Some(balloon) = d.as_any().downcast_ref::<crate::devices::virtio::balloon::Balloon>() {
+                        if balloon.track_free_pages() {
+                            has_balloon_tracking = true;
+                        }
+                    }
+                }
+                Ok(())
+            })
+            .unwrap();
+
+        // Perform free page optimization if balloon devices are tracking free pages
+        if has_balloon_tracking {
+            let free_pages_bitmap = collect_free_pages_for_zeroing(vmm, vm_info)?;
+            // Only zero pages if there are actually any free pages to optimize
+            if free_pages_bitmap.free_page_count() > 0 {
+                zero_free_pages_in_memory_file(&params.mem_file_path, &free_pages_bitmap)?;
+            }
         }
     }
 
@@ -197,31 +219,45 @@ pub fn create_snapshot(
 
 /// Collects free pages information from balloon devices for memory zeroing optimization.
 /// This creates a temporary bitmap for zeroing but doesn't save it to a file.
+/// Only collects data from balloon devices that have tracking enabled.
 fn collect_free_pages_for_zeroing(
     vmm: &Vmm,
     vm_info: &VmInfo,
 ) -> Result<crate::snapshot::free_pages::FreePagesbitmap, CreateSnapshotError> {
-    use crate::snapshot::free_pages::create_free_pages_bitmap;
-    use std::collections::HashSet;
+    use crate::snapshot::free_pages::create_free_pages_bitmap_from_iterator;
 
-    // Collect inflated pages from all balloon devices
-    let mut all_inflated_pages = HashSet::new();
+    // Calculate total memory pages (assuming 4KB pages)
+    const PAGE_SIZE: u32 = 4096;
+    let total_memory_bytes = vm_info.mem_size_mib * 1024 * 1024;
+    let total_pages = total_memory_bytes / PAGE_SIZE as u64;
+
+    // Create iterator chain for all inflated pages from all tracking-enabled balloon devices
+    let mut page_iterators: Vec<Box<dyn Iterator<Item = u32>>> = Vec::new();
+    let mut tracked_devices = 0;
+    let mut total_inflated_pages = 0;
 
     vmm.mmio_device_manager
         .for_each_virtio_device(|_, _, device_type, dev| {
             if device_type == &crate::devices::virtio::TYPE_BALLOON {
                 let d = dev.lock().unwrap();
                 if let Some(balloon) = d.as_any().downcast_ref::<crate::devices::virtio::balloon::Balloon>() {
-                    let inflated_pages = balloon.inflated_pages();
-                    all_inflated_pages.extend(inflated_pages.iter());
+                    // Only collect data from balloons that have tracking enabled
+                    if balloon.track_free_pages() {
+                        let inflated_pages = balloon.inflated_pages();
+                        total_inflated_pages += inflated_pages.len();
+                        tracked_devices += 1;
 
-                    // Log memory overhead information
-                    if let Some(overhead) = balloon.tracking_memory_overhead() {
-                        crate::logger::info!(
-                            "Balloon device inflated pages tracking overhead: {} KB, {} pages tracked",
-                            overhead / 1024,
-                            inflated_pages.len()
-                        );
+                        // Log memory overhead information
+                        if let Some(overhead) = balloon.tracking_memory_overhead() {
+                            crate::logger::info!(
+                                "Balloon device inflated pages tracking overhead: {} KB, {} pages tracked",
+                                overhead / 1024,
+                                inflated_pages.len()
+                            );
+                        }
+
+                        // Add iterator for this balloon's pages
+                        page_iterators.push(Box::new(inflated_pages.into_iter()));
                     }
                 }
             }
@@ -229,16 +265,15 @@ fn collect_free_pages_for_zeroing(
         })
         .unwrap();
 
-    // Calculate total memory pages (assuming 4KB pages)
-    const PAGE_SIZE: u32 = 4096;
-    let total_memory_bytes = vm_info.mem_size_mib * 1024 * 1024;
-    let total_pages = total_memory_bytes / PAGE_SIZE as u64;
+    // Chain all iterators together for memory-efficient processing
+    let chained_iterator = page_iterators.into_iter().flatten();
 
     // Create the bitmap for zeroing (but don't save to file)
-    let bitmap = create_free_pages_bitmap(&all_inflated_pages, total_pages, PAGE_SIZE)?;
+    let bitmap = create_free_pages_bitmap_from_iterator(chained_iterator, total_pages, PAGE_SIZE)?;
 
     crate::logger::info!(
-        "Collected free pages for memory zeroing: {} free pages out of {} total pages ({:.2}% free)",
+        "Collected free pages for memory zeroing from {} balloon devices: {} free pages out of {} total pages ({:.2}% free)",
+        tracked_devices,
         bitmap.free_page_count(),
         total_pages,
         (bitmap.free_page_count() as f64 / total_pages as f64) * 100.0
@@ -594,7 +629,8 @@ pub fn restore_from_snapshot(
         )
         .map_err(RestoreFromSnapshotGuestMemoryError::Uffd)?,
     };
-    builder::build_microvm_from_snapshot(
+
+    let vmm = builder::build_microvm_from_snapshot(
         instance_info,
         event_manager,
         microvm_state,
@@ -603,7 +639,9 @@ pub fn restore_from_snapshot(
         seccomp_filters,
         vm_resources,
     )
-    .map_err(RestoreFromSnapshotError::Build)
+    .map_err(RestoreFromSnapshotError::Build)?;
+
+    Ok(vmm)
 }
 
 /// Error type for [`snapshot_state_from_file`]
@@ -757,7 +795,6 @@ fn send_uffd_handshake(
         //      libc::SOL_SOCKET,
         //      libc::SO_PEERCRED,
         //      &mut val as *mut _ as *mut _,
-        //      &mut ucred_size as *mut libc::socklen_t,
         // );
         //
         // Per this linux man page: https://man7.org/linux/man-pages/man7/unix.7.html,
@@ -976,7 +1013,7 @@ mod tests {
         free_pages.insert(2); // Third page
 
         const PAGE_SIZE: u32 = 4096;
-        let bitmap = crate::snapshot::free_pages::FreePagesbitmap::new(&free_pages, 4, PAGE_SIZE).unwrap();
+        let bitmap = crate::snapshot::free_pages::FreePagesbitmap::from_pages(&free_pages, 4, PAGE_SIZE).unwrap();
 
         // Zero out the free pages
         zero_free_pages_in_memory_file(temp_file.path(), &bitmap).unwrap();

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -5,7 +5,7 @@
 
 use std::fmt::Debug;
 use std::fs::{File, OpenOptions};
-use std::io::{self, Write};
+use std::io::{self, Write, BufWriter, Seek, SeekFrom};
 use std::mem::forget;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::UnixStream;
@@ -174,8 +174,8 @@ pub fn create_snapshot(
         // Check if any balloon devices have tracking enabled
         let mut has_balloon_tracking = false;
         vmm.mmio_device_manager
-            .for_each_virtio_device(|_, _, device_type, dev| {
-                if device_type == &crate::devices::virtio::TYPE_BALLOON {
+            .for_each_virtio_device(|virtio_type, _, _, dev| {
+                if virtio_type == crate::devices::virtio::TYPE_BALLOON {
                     let d = dev.lock().unwrap();
                     if let Some(balloon) = d.as_any().downcast_ref::<crate::devices::virtio::balloon::Balloon>() {
                         if balloon.track_free_pages() {
@@ -183,7 +183,7 @@ pub fn create_snapshot(
                         }
                     }
                 }
-                Ok(())
+                Ok::<(), CreateSnapshotError>(())
             })
             .unwrap();
 
@@ -237,8 +237,8 @@ fn collect_free_pages_for_zeroing(
     let mut total_inflated_pages = 0;
 
     vmm.mmio_device_manager
-        .for_each_virtio_device(|_, _, device_type, dev| {
-            if device_type == &crate::devices::virtio::TYPE_BALLOON {
+        .for_each_virtio_device(|virtio_type, _, _, dev| {
+            if virtio_type == crate::devices::virtio::TYPE_BALLOON {
                 let d = dev.lock().unwrap();
                 if let Some(balloon) = d.as_any().downcast_ref::<crate::devices::virtio::balloon::Balloon>() {
                     // Only collect data from balloons that have tracking enabled
@@ -261,7 +261,7 @@ fn collect_free_pages_for_zeroing(
                     }
                 }
             }
-            Ok(())
+            Ok::<(), CreateSnapshotError>(())
         })
         .unwrap();
 
@@ -289,7 +289,6 @@ fn zero_free_pages_in_memory_file(
     bitmap: &crate::snapshot::free_pages::FreePagesbitmap,
 ) -> Result<(), CreateSnapshotError> {
     use std::fs::OpenOptions;
-    use std::io::{BufWriter, Seek, SeekFrom, Write};
 
     const PAGE_SIZE: u64 = 4096;
     const ZERO_BUFFER_SIZE: usize = 64 * 1024; // 64KB buffer for efficient I/O
@@ -308,10 +307,10 @@ fn zero_free_pages_in_memory_file(
     let mut bytes_zeroed = 0u64;
 
     // Process free pages in batches for efficiency
-    let mut current_batch = Vec::new();
+    let mut current_batch: Vec<u32> = Vec::new();
 
     // Collect all free pages into batches
-    for page_num in 0..bitmap.total_pages {
+    for page_num in 0..(bitmap.total_pages as u32) {
         if bitmap.is_page_free(page_num) {
             current_batch.push(page_num);
 

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -655,7 +655,7 @@ impl RuntimeApiController {
                 .vmm
                 .lock()
                 .expect("Poisoned lock")
-                .update_balloon_config(balloon_update.amount_mib)
+                .update_balloon_config(&balloon_update)
                 .map(|_| VmmData::Empty)
                 .map_err(|err| VmmActionError::BalloonConfig(BalloonConfigError::from(err))),
             UpdateBalloonStatistics(balloon_stats_update) => self

--- a/src/vmm/src/snapshot/free_pages.rs
+++ b/src/vmm/src/snapshot/free_pages.rs
@@ -1,0 +1,132 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Free pages bitmap management for snapshot memory zeroing optimization.
+//!
+//! This module provides functionality to track pages that are inflated by the
+//! balloon device and should be considered free from the guest perspective.
+//! This information is used to zero free pages in memory files for better compression.
+
+use std::collections::HashSet;
+
+/// Error type for free pages bitmap operations.
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
+pub enum FreePagesError {
+    /// Invalid page frame number: {0} exceeds total pages {1}
+    InvalidPageNumber(u32, u64),
+}
+
+/// Memory-efficient bitmap for tracking free pages using bit vectors.
+#[derive(Debug)]
+pub struct FreePagesbitmap {
+    /// Bitmap where each bit represents whether a page is free (1) or not (0).
+    /// Much more memory efficient than storing individual page numbers.
+    pub bitmap: Vec<u8>,
+    /// Total number of memory pages in the guest.
+    pub total_pages: u64,
+    /// Page size in bytes (typically 4096).
+    pub page_size: u32,
+}
+
+impl FreePagesbitmap {
+    /// Creates a new free pages bitmap from a set of page numbers.
+    pub fn new(
+        free_pages: &HashSet<u32>,
+        total_pages: u64,
+        page_size: u32,
+    ) -> Result<Self, FreePagesError> {
+        // Calculate bitmap size in bytes (1 bit per page, rounded up to byte boundary)
+        let bitmap_bytes = ((total_pages + 7) / 8) as usize;
+        let mut bitmap = vec![0u8; bitmap_bytes];
+
+        // Set bits for free pages
+        for &page_num in free_pages {
+            if page_num as u64 >= total_pages {
+                return Err(FreePagesError::InvalidPageNumber(page_num, total_pages));
+            }
+            let byte_idx = (page_num / 8) as usize;
+            let bit_idx = page_num % 8;
+            bitmap[byte_idx] |= 1 << bit_idx;
+        }
+
+        Ok(Self {
+            bitmap,
+            total_pages,
+            page_size,
+        })
+    }
+
+    /// Returns the number of free pages by counting set bits.
+    pub fn free_page_count(&self) -> usize {
+        self.bitmap.iter().map(|byte| byte.count_ones() as usize).sum()
+    }
+
+    /// Checks if a page is marked as free.
+    pub fn is_page_free(&self, page_frame_number: u32) -> bool {
+        if page_frame_number as u64 >= self.total_pages {
+            return false;
+        }
+        let byte_idx = (page_frame_number / 8) as usize;
+        let bit_idx = page_frame_number % 8;
+        (self.bitmap[byte_idx] & (1 << bit_idx)) != 0
+    }
+}
+
+/// Creates a free pages bitmap from balloon device inflated pages.
+/// This is used for memory zeroing optimization during snapshot creation.
+pub fn create_free_pages_bitmap(
+    inflated_pages: &HashSet<u32>,
+    total_memory_pages: u64,
+    page_size: u32,
+) -> Result<FreePagesbitmap, FreePagesError> {
+    FreePagesbitmap::new(inflated_pages, total_memory_pages, page_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bitmap_operations() {
+        let mut free_pages = HashSet::new();
+        free_pages.insert(100);
+        free_pages.insert(200);
+        free_pages.insert(300);
+
+        let bitmap = FreePagesbitmap::new(&free_pages, 1000, 4096).unwrap();
+
+        // Test is_page_free
+        assert!(bitmap.is_page_free(100));
+        assert!(bitmap.is_page_free(200));
+        assert!(bitmap.is_page_free(300));
+        assert!(!bitmap.is_page_free(150));
+
+        // Test free_page_count
+        assert_eq!(bitmap.free_page_count(), 3);
+    }
+
+    #[test]
+    fn test_bitmap_memory_efficiency() {
+        // Test that bitmap uses minimal memory
+        let total_pages = 1_000_000u64; // ~4GB worth of pages
+        let free_pages = HashSet::new(); // Empty set
+        let bitmap = FreePagesbitmap::new(&free_pages, total_pages, 4096).unwrap();
+
+        // Bitmap should use about 125KB (1M bits / 8 bits per byte)
+        let expected_bitmap_bytes = ((total_pages + 7) / 8) as usize;
+        assert_eq!(bitmap.bitmap.len(), expected_bitmap_bytes);
+    }
+
+    #[test]
+    fn test_create_free_pages_bitmap() {
+        let mut inflated_pages = HashSet::new();
+        inflated_pages.insert(42);
+        inflated_pages.insert(1337);
+
+        let bitmap = create_free_pages_bitmap(&inflated_pages, 10000, 4096).unwrap();
+        assert!(bitmap.is_page_free(42));
+        assert!(bitmap.is_page_free(1337));
+        assert!(!bitmap.is_page_free(500));
+        assert_eq!(bitmap.free_page_count(), 2);
+    }
+}

--- a/src/vmm/src/snapshot/free_pages.rs
+++ b/src/vmm/src/snapshot/free_pages.rs
@@ -29,31 +29,40 @@ pub struct FreePagesbitmap {
 }
 
 impl FreePagesbitmap {
+    /// Creates a new empty free pages bitmap.
+    pub fn new(total_pages: u64, page_size: u32) -> Self {
+        // Calculate bitmap size in bytes (1 bit per page, rounded up to byte boundary)
+        let bitmap_bytes = ((total_pages + 7) / 8) as usize;
+        Self {
+            bitmap: vec![0u8; bitmap_bytes],
+            total_pages,
+            page_size,
+        }
+    }
+
     /// Creates a new free pages bitmap from a set of page numbers.
-    pub fn new(
+    /// This method is kept for compatibility but should be avoided for large page sets.
+    pub fn from_pages(
         free_pages: &HashSet<u32>,
         total_pages: u64,
         page_size: u32,
     ) -> Result<Self, FreePagesError> {
-        // Calculate bitmap size in bytes (1 bit per page, rounded up to byte boundary)
-        let bitmap_bytes = ((total_pages + 7) / 8) as usize;
-        let mut bitmap = vec![0u8; bitmap_bytes];
-
-        // Set bits for free pages
+        let mut bitmap = Self::new(total_pages, page_size);
         for &page_num in free_pages {
-            if page_num as u64 >= total_pages {
-                return Err(FreePagesError::InvalidPageNumber(page_num, total_pages));
-            }
-            let byte_idx = (page_num / 8) as usize;
-            let bit_idx = page_num % 8;
-            bitmap[byte_idx] |= 1 << bit_idx;
+            bitmap.set_page_free(page_num)?;
         }
+        Ok(bitmap)
+    }
 
-        Ok(Self {
-            bitmap,
-            total_pages,
-            page_size,
-        })
+    /// Sets a page as free.
+    pub fn set_page_free(&mut self, page_num: u32) -> Result<(), FreePagesError> {
+        if page_num as u64 >= self.total_pages {
+            return Err(FreePagesError::InvalidPageNumber(page_num, self.total_pages));
+        }
+        let byte_idx = (page_num / 8) as usize;
+        let bit_idx = page_num % 8;
+        self.bitmap[byte_idx] |= 1 << bit_idx;
+        Ok(())
     }
 
     /// Returns the number of free pages by counting set bits.
@@ -72,14 +81,33 @@ impl FreePagesbitmap {
     }
 }
 
+/// Creates a free pages bitmap by directly setting pages without requiring a HashSet.
+/// This function is more memory-efficient as it doesn't create intermediate collections.
+pub fn create_free_pages_bitmap_from_iterator<I>(
+    inflated_pages: I,
+    total_memory_pages: u64,
+    page_size: u32,
+) -> Result<FreePagesbitmap, FreePagesError>
+where
+    I: Iterator<Item = u32>,
+{
+    let mut bitmap = FreePagesbitmap::new(total_memory_pages, page_size);
+    for page_num in inflated_pages {
+        bitmap.set_page_free(page_num)?;
+    }
+    Ok(bitmap)
+}
+
 /// Creates a free pages bitmap from balloon device inflated pages.
 /// This is used for memory zeroing optimization during snapshot creation.
+///
+/// **Deprecated**: Use `create_free_pages_bitmap_from_iterator` for better memory efficiency.
 pub fn create_free_pages_bitmap(
     inflated_pages: &HashSet<u32>,
     total_memory_pages: u64,
     page_size: u32,
 ) -> Result<FreePagesbitmap, FreePagesError> {
-    FreePagesbitmap::new(inflated_pages, total_memory_pages, page_size)
+    FreePagesbitmap::from_pages(inflated_pages, total_memory_pages, page_size)
 }
 
 #[cfg(test)]
@@ -88,12 +116,11 @@ mod tests {
 
     #[test]
     fn test_bitmap_operations() {
-        let mut free_pages = HashSet::new();
-        free_pages.insert(100);
-        free_pages.insert(200);
-        free_pages.insert(300);
+        let mut bitmap = FreePagesbitmap::new(1000, 4096);
 
-        let bitmap = FreePagesbitmap::new(&free_pages, 1000, 4096).unwrap();
+        bitmap.set_page_free(100).unwrap();
+        bitmap.set_page_free(200).unwrap();
+        bitmap.set_page_free(300).unwrap();
 
         // Test is_page_free
         assert!(bitmap.is_page_free(100));
@@ -109,8 +136,7 @@ mod tests {
     fn test_bitmap_memory_efficiency() {
         // Test that bitmap uses minimal memory
         let total_pages = 1_000_000u64; // ~4GB worth of pages
-        let free_pages = HashSet::new(); // Empty set
-        let bitmap = FreePagesbitmap::new(&free_pages, total_pages, 4096).unwrap();
+        let bitmap = FreePagesbitmap::new(total_pages, 4096);
 
         // Bitmap should use about 125KB (1M bits / 8 bits per byte)
         let expected_bitmap_bytes = ((total_pages + 7) / 8) as usize;
@@ -118,7 +144,22 @@ mod tests {
     }
 
     #[test]
-    fn test_create_free_pages_bitmap() {
+    fn test_create_free_pages_bitmap_from_iterator() {
+        let inflated_pages = vec![42, 1337];
+        let bitmap = create_free_pages_bitmap_from_iterator(
+            inflated_pages.into_iter(),
+            10000,
+            4096
+        ).unwrap();
+
+        assert!(bitmap.is_page_free(42));
+        assert!(bitmap.is_page_free(1337));
+        assert!(!bitmap.is_page_free(500));
+        assert_eq!(bitmap.free_page_count(), 2);
+    }
+
+    #[test]
+    fn test_legacy_create_free_pages_bitmap() {
         let mut inflated_pages = HashSet::new();
         inflated_pages.insert(42);
         inflated_pages.insert(1337);

--- a/src/vmm/src/snapshot/mod.rs
+++ b/src/vmm/src/snapshot/mod.rs
@@ -24,6 +24,7 @@
 //! The snapshot format uses a version value in the form of `MAJOR.MINOR.PATCH`. The version is
 //! provided by the library clients (it is not tied to this crate).
 pub mod crc;
+pub mod free_pages;
 mod persist;
 use std::fmt::Debug;
 use std::io::{Read, Write};

--- a/src/vmm/src/vmm_config/balloon.rs
+++ b/src/vmm/src/vmm_config/balloon.rs
@@ -114,6 +114,7 @@ impl BalloonBuilder {
             // `restored` flag is false because this code path
             // is never called by snapshot restore functionality.
             false,
+            cfg.track_free_pages,
         )?)));
 
         Ok(())

--- a/src/vmm/src/vmm_config/balloon.rs
+++ b/src/vmm/src/vmm_config/balloon.rs
@@ -44,6 +44,13 @@ pub struct BalloonDeviceConfig {
     /// Interval in seconds between refreshing statistics.
     #[serde(default)]
     pub stats_polling_interval_s: u16,
+    /// Whether to track inflated pages for snapshot optimization.
+    /// When enabled, the balloon device will maintain a bitmap of inflated pages
+    /// that can be used during snapshot creation to zero free pages in memory files
+    /// for better compression. This adds minimal runtime overhead but improves
+    /// snapshot compression ratios.
+    #[serde(default)]
+    pub track_free_pages: bool,
 }
 
 impl From<BalloonConfig> for BalloonDeviceConfig {
@@ -52,6 +59,7 @@ impl From<BalloonConfig> for BalloonDeviceConfig {
             amount_mib: state.amount_mib,
             deflate_on_oom: state.deflate_on_oom,
             stats_polling_interval_s: state.stats_polling_interval_s,
+            track_free_pages: state.track_free_pages,
         }
     }
 }
@@ -63,6 +71,13 @@ impl From<BalloonConfig> for BalloonDeviceConfig {
 pub struct BalloonUpdateConfig {
     /// Target balloon size in MiB.
     pub amount_mib: u32,
+    /// Whether to track inflated pages for snapshot optimization.
+    /// When enabled, the balloon device will maintain a bitmap of inflated pages
+    /// that can be used during snapshot creation to zero free pages in memory files
+    /// for better compression. This adds minimal runtime overhead but improves
+    /// snapshot compression ratios. Can be toggled at runtime.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub track_free_pages: Option<bool>,
 }
 
 /// The data fed into a balloon statistics interval update request.
@@ -141,6 +156,7 @@ pub(crate) mod tests {
             amount_mib: 0,
             deflate_on_oom: false,
             stats_polling_interval_s: 0,
+            track_free_pages: false,
         }
     }
 
@@ -151,6 +167,7 @@ pub(crate) mod tests {
             amount_mib: 0,
             deflate_on_oom: false,
             stats_polling_interval_s: 0,
+            track_free_pages: false,
         };
         assert_eq!(default_balloon_config, balloon_config);
         let mut builder = BalloonBuilder::new();
@@ -160,7 +177,10 @@ pub(crate) mod tests {
         assert_eq!(builder.get().unwrap().lock().unwrap().num_pages(), 0);
         assert_eq!(builder.get_config().unwrap(), default_balloon_config);
 
-        let _update_config = BalloonUpdateConfig { amount_mib: 5 };
+        let _update_config = BalloonUpdateConfig {
+            amount_mib: 5,
+            track_free_pages: None,
+        };
         let _stats_update_config = BalloonUpdateStatsConfig {
             stats_polling_interval_s: 5,
         };
@@ -172,12 +192,14 @@ pub(crate) mod tests {
             amount_mib: 5,
             deflate_on_oom: false,
             stats_polling_interval_s: 3,
+            track_free_pages: false,
         };
 
         let actual_balloon_config = BalloonDeviceConfig::from(BalloonConfig {
             amount_mib: 5,
             deflate_on_oom: false,
             stats_polling_interval_s: 3,
+            track_free_pages: false,
         });
 
         assert_eq!(expected_balloon_config, actual_balloon_config);


### PR DESCRIPTION
During snapshot, these tracked free pages can mark pages in our mem file as zero and reduce snapshot size